### PR TITLE
Implement markdown writer command

### DIFF
--- a/remarking/cli/commands/md_writer_command.py
+++ b/remarking/cli/commands/md_writer_command.py
@@ -1,0 +1,86 @@
+import typing as T
+from typing import List
+
+from remarking import Writer
+from remarking import WriterCommand
+from remarking import ClickOption
+from remarking import CommandLineLogger
+from remarking import Highlight
+from remarking import Document
+
+import click
+
+
+class MDWriter(Writer):
+    """ Writes a md document to output.  """
+
+    def __init__(self,
+                 documents: List[Document],
+                 highlights: List[Highlight],
+                 add_pages: bool,
+                 ) -> None:
+        self.documents = documents
+        self.highlights = highlights
+        self.add_pages = add_pages
+
+    def write(self, logger: CommandLineLogger) -> None:
+        """ Write to output. Invoked by remarking after extraction is ran on documents. """
+        md_string = []
+        for document in self.documents:
+            """ Write document name as the heading """
+            md_string.append("# " + document.name)
+
+            for highlight in self.highlights:
+                if highlight.document_id == document.id:
+                    """ Write highlight text as blockquote with page number in brackets at the end """
+                    if self.add_pages:
+                        md_string.append(f'> "{highlight.text}" (p. {highlight.page_number})')
+                    else:
+                        md_string.append(f'> "{highlight.text}"')
+
+        logger.output_result("\n\n".join(md_string) + "\n")
+
+
+
+
+class MDWriterCommand(WriterCommand):
+    """ MD Writer Command for: `md` output writer. """
+
+    def name(self) -> str:
+        """ Return the name of the command as referenced on the command line. """
+        return "md"
+
+    def options(self) -> List[ClickOption]:
+        """ Return a list of click options to use for the command.
+
+        The list can be constructed from the return value of :func:`click.option`.
+
+        These options will be added to the default options for the run or persist command.
+        """
+        return [
+            click.option("--pages/--no-pages",
+                         "-p",
+                         "add_pages",
+                         default=False,
+                         help="Add page numbers to blockquote"
+                        )
+        ]
+
+    def long_description(self) -> str:
+        """ The long description for your command. Shown when running ``--help`` """
+        return """
+        
+        Returns documents and highlights as a Markdown document
+        """
+
+    def short_description(self) -> str:
+        """ The short description of your command. """
+        return "Output results as a MD document"
+
+    def writer(self,
+               documents: List[Document],
+               highlights: List[Highlight],
+               **kwargs: T.Any) -> Writer:
+        """ Parse options and return a configured instance of a concrete :class:`Writer` class. """
+        add_pages = kwargs['add_pages']
+        return MDWriter(documents, highlights, add_pages)

--- a/remarking/cli/commands/md_writer_command.py
+++ b/remarking/cli/commands/md_writer_command.py
@@ -27,12 +27,12 @@ class MDWriter(Writer):
         """ Write to output. Invoked by remarking after extraction is ran on documents. """
         md_string = []
         for document in self.documents:
-            """ Write document name as the heading """
+            # Write document name as the heading
             md_string.append("# " + document.name)
 
             for highlight in self.highlights:
                 if highlight.document_id == document.id:
-                    """ Write highlight text as blockquote with page number in brackets at the end """
+                    # Write highlight text as blockquote with page number in brackets at the end
                     if self.add_pages:
                         md_string.append(f'> "{highlight.text}" (p. {highlight.page_number})')
                     else:

--- a/remarking/cli/commands/md_writer_command.py
+++ b/remarking/cli/commands/md_writer_command.py
@@ -72,7 +72,7 @@ class MDWriterCommand(WriterCommand):
 
     def short_description(self) -> str:
         """ The short description of your command. """
-        return "Output results as a MD document"
+        return "Output results as markdown"
 
     def writer(self,
                documents: List[Document],

--- a/remarking/cli/commands/md_writer_command.py
+++ b/remarking/cli/commands/md_writer_command.py
@@ -68,10 +68,7 @@ class MDWriterCommand(WriterCommand):
 
     def long_description(self) -> str:
         """ The long description for your command. Shown when running ``--help`` """
-        return """
-        
-        Returns documents and highlights as a Markdown document
-        """
+        return "Returns documents and highlights as a Markdown document"
 
     def short_description(self) -> str:
         """ The short description of your command. """

--- a/remarking/cli/commands/md_writer_command.py
+++ b/remarking/cli/commands/md_writer_command.py
@@ -1,14 +1,10 @@
 import typing as T
 from typing import List
 
-from remarking import Writer
-from remarking import WriterCommand
-from remarking import ClickOption
-from remarking import CommandLineLogger
-from remarking import Highlight
-from remarking import Document
-
 import click
+
+from remarking import (ClickOption, CommandLineLogger, Document, Highlight,
+                       Writer, WriterCommand)
 
 
 class MDWriter(Writer):
@@ -39,8 +35,6 @@ class MDWriter(Writer):
                         md_string.append(f'> "{highlight.text}"')
 
         logger.output_result("\n\n".join(md_string) + "\n")
-
-
 
 
 class MDWriterCommand(WriterCommand):

--- a/tests/cli/commands/test_md_writer_command.py
+++ b/tests/cli/commands/test_md_writer_command.py
@@ -1,0 +1,59 @@
+# pylint: disable=no-self-use,missing-function-docstring,
+
+import typing as T
+from typing import Dict, List
+
+from _pytest.capture import CaptureFixture
+from click.testing import CliRunner
+import re
+
+from remarking import models
+from remarking.cli import app as app_
+from remarking.cli import cli, log
+from remarking.cli.commands import md_writer_command
+
+def test_md_writer(capsys: CaptureFixture,
+                      logger: log.CommandLineLogger,
+                      documents: List[models.Document],
+                      highlights: List[models.Highlight],
+                      normalized_highlights: List[Dict[str, T.Any]]) -> None:
+    md_writer = md_writer_command.MDWriter(documents, highlights, add_pages=False)
+    md_writer.write(logger=logger)
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert captured.out != ""
+
+    lines = captured.out.split("\n\n")
+    for line in lines:
+        assert line.startswith("# ") or line.startswith("> ")
+
+def test_md_writer_with_pages(capsys: CaptureFixture,
+                      logger: log.CommandLineLogger,
+                      documents: List[models.Document],
+                      highlights: List[models.Highlight],
+                      normalized_highlights: List[Dict[str, T.Any]]) -> None:
+    md_writer = md_writer_command.MDWriter(documents, highlights, add_pages=True)
+    md_writer.write(logger=logger)
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert captured.out != ""
+
+    lines = captured.out.split("\n\n")
+    for line in lines:
+        if line.startswith("> "):
+            m = re.search(r'\(p\. \d+\)$', line)
+            assert m is not None
+
+class TestMDWriterCommand():
+
+    def test_run_md(self, mock_app: app_.App, normalized_highlights: List[Dict[str, T.Any]]) -> None:
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(cli.command_line, args=["run", "md", "--token", "test", "books"])
+
+        assert "Extractors:" in result.stderr
+        assert "Collections:" in result.stderr
+        assert "Connecting to RM cloud" in result.stderr
+
+        assert normalized_highlights[0]['document_name'] in result.stdout


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #7 (just for tracking)

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
I followed the excellent documentation to create a WriterCommand for a simple markdown writer

- Markdown writer outputs simple markdown formatted string
- Uses document name as header
- Formats highlights as blockquotes
- Highlight page can be added at the end of the blockquote with an option
- Added tests (first time writing Python tests 🙈, feedback appreciated)

Here's what I've managed to come up with. Let me know what you think.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Thank you for this amazing project. This is what I was missing from my remarkable workflow 😊

@sabidib 